### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,16 @@ dist: trusty
 language: php
 
 php:
+    - 5.5
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
+    - hhvm
+
+matrix:
+    allow_failures:
+        - php: hhvm
 
 before_script:
     - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 language: php
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
@@ -16,7 +15,6 @@ matrix:
 
 before_script:
     - travis_retry composer self-update
-    - if [[ $TRAVIS_PHP_VERSION == "5.5" ]]; then composer remove --dev phpbench/phpbench; fi
     - if [[ $TRAVIS_PHP_VERSION == "hhvm" ]]; then composer remove --dev phpbench/phpbench; fi
     - travis_retry composer install --no-interaction
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php" : "^5.6 || ^7.0",
+        "php" : "^5.5 || ^7.0",
         "robinvdvleuten/ulid": "^1.0",
         "lewiscowles/ulid": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "robinvdvleuten/ulid": "^1.0",
         "lewiscowles/ulid": "^1.2"
     },
+    "suggest": {
+        "ext-gmp": "It can let string encoding progress be fast."
+    },
     "autoload": {
         "psr-4": {
             "Tuupola\\": "src"
@@ -31,7 +34,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8 || ^5.5 || ^6.5",
         "paragonie/random_compat": "^2.0",
         "phpbench/phpbench": "^0.13.0",
         "overtrue/phplint": "^0.2.1"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php" : "^5.5 || ^7.0",
+        "php" : "^5.6 || ^7.0",
         "robinvdvleuten/ulid": "^1.0",
         "lewiscowles/ulid": "^1.2"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,9 @@
         </testsuite>
     </testsuites>
     <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
         <blacklist>
             <directory suffix=".php">vendor/</directory>
         </blacklist>

--- a/tests/Base32Test.php
+++ b/tests/Base32Test.php
@@ -17,8 +17,9 @@ namespace Tuupola\Base32;
 
 use Tuupola\Base32;
 use Tuupola\Base32Proxy;
+use PHPUnit\Framework\TestCase;
 
-class Base32Test extends \PHPUnit_Framework_TestCase
+class Base32Test extends TestCase
 {
 
     public function testShouldBeTrue()
@@ -40,6 +41,8 @@ class Base32Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals("MZXW6YTB", $encoded);
         $encoded = (new PhpEncoder)->encode("foobar");
         $this->assertEquals("MZXW6YTBOI======", $encoded);
+        $encoded = (new PhpEncoder)->encode(null);
+        $this->assertEquals("", $encoded);
 
         $encoded = (new GmpEncoder)->encode("f");
         $this->assertEquals("MY======", $encoded);
@@ -53,6 +56,8 @@ class Base32Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals("MZXW6YTB", $encoded);
         $encoded = (new GmpEncoder)->encode("foobar");
         $this->assertEquals("MZXW6YTBOI======", $encoded);
+        $encoded = (new GmpEncoder)->encode(null);
+        $this->assertEquals("", $encoded);
     }
 
     public function testShouldDecodeFoobar()
@@ -69,6 +74,8 @@ class Base32Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals("fooba", $decoded);
         $decoded = (new PhpEncoder)->decode("MZXW6YTBOI======");
         $this->assertEquals("foobar", $decoded);
+        $decoded = (new PhpEncoder)->decode(null);
+        $this->assertEquals("", $decoded);
 
         $decoded = (string) (new GmpEncoder)->decode("MY======");
         $this->assertEquals("f", $decoded);
@@ -82,6 +89,9 @@ class Base32Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals("fooba", $decoded);
         $decoded = (new GmpEncoder)->decode("MZXW6YTBOI======");
         $this->assertEquals("foobar", $decoded);
+        $decoded = (new GmpEncoder)->decode(null);
+        $this->assertEquals("", $decoded);
+        
     }
 
 

--- a/tests/Base32Test.php
+++ b/tests/Base32Test.php
@@ -91,7 +91,6 @@ class Base32Test extends TestCase
         $this->assertEquals("foobar", $decoded);
         $decoded = (new GmpEncoder)->decode(null);
         $this->assertEquals("", $decoded);
-        
     }
 
 


### PR DESCRIPTION
# Changed log

- add more tests.
- remove ```php-5.5``` test because of the ```gmp_import``` function.
- use the class-based PHPUnit namespace.
- set the different PHPUnit version for the different PHP version.