### PR TITLE
Add support for Crockford mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## [0.3.0](https://github.com/tuupola/base32/compare/0.2.0...master) - unreleased
+- Support for Crockford mode ([#8](https://github.com/tuupola/base32/pull/8)).
+
 ## [0.2.0](https://github.com/tuupola/base32/compare/0.1.1...0.2.0) - 2019-05-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ print $gmp->encode("Hello world!"); /* 91IMOR3F41RMUSJCCGGG */
 
 ### Crockford's Base32
 
-When decoding, upper and lower case letters are accepted, and i and l will be treated as 1 and o will be treated as 0. When encoding, only upper case letters are used.
+When decoding, upper and lower case letters are accepted, and i and l will be treated as 1 and o will be treated as 0. When encoding, only upper case letters are used. Hyphens are ignored during decoding.
 
 ```php
 $crockford = new Base32([

--- a/README.md
+++ b/README.md
@@ -79,8 +79,22 @@ $gmp = new Base32([
 print $gmp->encode("Hello world!"); /* 91IMOR3F41RMUSJCCGGG */
 ```
 
-### Crockford's Base32 [WIP]
-http://www.crockford.com/wrmg/base32.html
+### Crockford's Base32
+
+When decoding, upper and lower case letters are accepted, and i and l will be treated as 1 and o will be treated as 0. When encoding, only upper case letters are used.
+
+```php
+$crockford = new Base32([
+    "characters" => Base32::CROCKFORD,
+    "padding" => false,
+    "crocford" => true,
+]);
+
+print $crockford->encode("Hello world!"); /* 91JPRV3F41VPYWKCCGGG */
+print $crockford->decode("91JPRV3F41VPYWKCCGGG"); /* Hello world! */
+print $crockford->decode("91jprv3f41vpywkccggg"); /* Hello world! */
+print $crockford->decode("9ljprv3f4lvpywkccggg"); /* Hello world! */
+```
 
 ### Z-base-32 [WIP]
 http://philzimmermann.com/docs/human-oriented-base-32-encoding.txt

--- a/src/Base32/GmpEncoder.php
+++ b/src/Base32/GmpEncoder.php
@@ -23,6 +23,7 @@ class GmpEncoder
     private $options = [
         "characters" => Base32::RFC4648,
         "padding" => "=",
+        "crockford" => false,
     ];
 
     public function __construct($options = [])
@@ -79,6 +80,11 @@ class GmpEncoder
     {
         if (empty($data)) {
             return "";
+        }
+
+        if (true === $this->options["crockford"]) {
+            $data = strtoupper($data);
+            $data = str_replace(["O", "L", "I"], ["0", "1", "1"], $data);
         }
 
         /* If the data contains characters that aren't in the character set. */

--- a/src/Base32/GmpEncoder.php
+++ b/src/Base32/GmpEncoder.php
@@ -84,7 +84,7 @@ class GmpEncoder
 
         if (true === $this->options["crockford"]) {
             $data = strtoupper($data);
-            $data = str_replace(["O", "L", "I"], ["0", "1", "1"], $data);
+            $data = str_replace(["O", "L", "I", "-"], ["0", "1", "1", ""], $data);
         }
 
         /* If the data contains characters that aren't in the character set. */

--- a/src/Base32/PhpEncoder.php
+++ b/src/Base32/PhpEncoder.php
@@ -86,7 +86,7 @@ class PhpEncoder
 
         if (true === $this->options["crockford"]) {
             $data = strtoupper($data);
-            $data = str_replace(["O", "L", "I"], ["0", "1", "1"], $data);
+            $data = str_replace(["O", "L", "I", "-"], ["0", "1", "1", ""], $data);
         }
 
         /* If the data contains characters that aren't in the character set. */

--- a/src/Base32/PhpEncoder.php
+++ b/src/Base32/PhpEncoder.php
@@ -23,6 +23,7 @@ class PhpEncoder
     private $options = [
         "characters" => Base32::RFC4648,
         "padding" => "=",
+        "crockford" => false,
     ];
 
     public function __construct($options = [])
@@ -81,6 +82,11 @@ class PhpEncoder
     {
         if (empty($data)) {
             return "";
+        }
+
+        if (true === $this->options["crockford"]) {
+            $data = strtoupper($data);
+            $data = str_replace(["O", "L", "I"], ["0", "1", "1"], $data);
         }
 
         /* If the data contains characters that aren't in the character set. */

--- a/tests/Base32Test.php
+++ b/tests/Base32Test.php
@@ -399,7 +399,7 @@ class Base32Test extends TestCase
     {
         $encoded1 = "91JPRV3F41VPYWKCCGGJ0Y3R";
         $encoded2 = "91jprv3f41vpywkccggj0y3r";
-        $encoded3 = "9ljprv3f41vpywkccggjoy3r";
+        $encoded3 = "9ljp-rv3f4-1vpyw-kccgg-joy3r";
 
         $data = "Hello world! xx";
         $configuration = [

--- a/tests/Base32Test.php
+++ b/tests/Base32Test.php
@@ -395,6 +395,30 @@ class Base32Test extends TestCase
         }
     }
 
+    public function testShouldHandleCrockford()
+    {
+        $encoded1 = "91JPRV3F41VPYWKCCGGJ0Y3R";
+        $encoded2 = "91jprv3f41vpywkccggj0y3r";
+        $encoded3 = "9ljprv3f41vpywkccggjoy3r";
+
+        $data = "Hello world! xx";
+        $configuration = [
+            "characters" => Base32::CROCKFORD,
+            "padding" => false,
+            "crockford" => true,
+        ];
+        $php = new PhpEncoder($configuration);
+        $gmp = new GmpEncoder($configuration);
+
+        $this->assertEquals($data, $php->decode($encoded1));
+        $this->assertEquals($data, $php->decode($encoded2));
+        $this->assertEquals($data, $php->decode($encoded3));
+
+        $this->assertEquals($data, $gmp->decode($encoded1));
+        $this->assertEquals($data, $gmp->decode($encoded2));
+        $this->assertEquals($data, $gmp->decode($encoded3));
+    }
+
     public function configurationProvider()
     {
         return [
@@ -409,6 +433,11 @@ class Base32Test extends TestCase
             "GMP mode" => [[
                 "characters" => Base32::GMP,
                 "padding" => false,
+            ]],
+            "Crockford mode" => [[
+                "characters" => Base32::CROCKFORD,
+                "padding" => false,
+                "crocford" => true,
             ]],
             "Custom character set" => [[
                 "characters" => "ABCDEFGHIJKLMNOPQRSTUV0123456789",


### PR DESCRIPTION
When decoding, upper and lower case letters are accepted, and i and l will be treated as 1 and o will be treated as 0. When encoding, only upper case letters are used.