### PR TITLE
Fix cannot decode empty string as integer errors

### DIFF
--- a/src/Base32/GmpEncoder.php
+++ b/src/Base32/GmpEncoder.php
@@ -156,7 +156,7 @@ class GmpEncoder extends BaseEncoder
      */
     public function decodeInteger(string $data): int
     {
-        if (empty($data)) {
+        if ($data === "") {
             throw new InvalidArgumentException(
                 "Cannot decode empty string as integer"
             );

--- a/src/Base32/PhpEncoder.php
+++ b/src/Base32/PhpEncoder.php
@@ -157,7 +157,7 @@ class PhpEncoder extends BaseEncoder
      */
     public function decodeInteger(string $data): int
     {
-        if (empty($data)) {
+        if ($data === "") {
             throw new InvalidArgumentException(
                 "Cannot decode empty string as integer"
             );


### PR DESCRIPTION
In PHP empty("0") evaluates to true so check for emptry string instead.