### PR TITLE
Fix cannot decode empty string as integer  (fixes #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## [2.0.1](https://github.com/tuupola/base32/compare/2.0.0...2.0.1) - unreleased
+
+### Fixed
+- Roundtrip of decoding and encoding integer 0 failed with some settings ([#30](https://github.com/tuupola/base32/issues/30), [#40](https://github.com/tuupola/base32/pull/40/files)).
+
 ## [2.0.0](https://github.com/tuupola/base32/compare/1.0.0...2.0.0) - 2020-11-19
 
 ### Added

--- a/src/Base32/GmpEncoder.php
+++ b/src/Base32/GmpEncoder.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 /*
 
-Copyright (c) 2017-2020 Mika Tuupola
+Copyright (c) 2017-2025 Mika Tuupola
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Base32/GmpEncoder.php
+++ b/src/Base32/GmpEncoder.php
@@ -156,7 +156,7 @@ class GmpEncoder extends BaseEncoder
      */
     public function decodeInteger(string $data): int
     {
-        if (empty($data)) {
+        if ($data === "") {
             throw new InvalidArgumentException(
                 "Cannot decode empty string as integer"
             );

--- a/src/Base32/PhpEncoder.php
+++ b/src/Base32/PhpEncoder.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 /*
 
-Copyright (c) 2017-2020 Mika Tuupola
+Copyright (c) 2017-2025 Mika Tuupola
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Base32/PhpEncoder.php
+++ b/src/Base32/PhpEncoder.php
@@ -157,7 +157,7 @@ class PhpEncoder extends BaseEncoder
      */
     public function decodeInteger(string $data): int
     {
-        if (empty($data)) {
+        if ($data === "") {
             throw new InvalidArgumentException(
                 "Cannot decode empty string as integer"
             );

--- a/tests/Base32Test.php
+++ b/tests/Base32Test.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 /*
 
-Copyright (c) 2017-2020 Mika Tuupola
+Copyright (c) 2017-2025 Mika Tuupola
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -441,6 +441,34 @@ class Base32Test extends TestCase
         $this->assertEquals($data, $gmp->decode($encoded1));
         $this->assertEquals($data, $gmp->decode($encoded2));
         $this->assertEquals($data, $gmp->decode($encoded3));
+    }
+
+    /**
+     * @dataProvider configurationProvider
+     */
+    public function testBug30ShouldEncodeAndDecodeZero($configuration)
+    {
+        $data = 0;
+
+        $php = new PhpEncoder($configuration);
+        $gmp = new GmpEncoder($configuration);
+        $base32 = new Base32($configuration);
+
+        $encoded = $php->encodeInteger($data);
+        $encoded2 = $gmp->encodeInteger($data);
+        $encoded4 = $base32->encodeInteger($data);
+
+        Base32Proxy::$options = $configuration;
+        $encoded5 = Base32Proxy::encodeInteger($data);
+
+        $this->assertEquals($encoded2, $encoded);
+        $this->assertEquals($encoded4, $encoded);
+        $this->assertEquals($encoded5, $encoded);
+
+        $this->assertEquals($data, $php->decodeInteger($encoded));
+        $this->assertEquals($data, $gmp->decodeInteger($encoded2));
+        $this->assertEquals($data, $base32->decodeInteger($encoded4));
+        $this->assertEquals($data, Base32Proxy::decodeInteger($encoded5));
     }
 
     public function configurationProvider()


### PR DESCRIPTION
PHP considers empty("0") to be true so roundtrip of encoding and
decoding integer 0 failed with some settings.
